### PR TITLE
Fixed an issue where the api_key value was being removed from the sta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.1.4
+
+#### Product:
+
+- Fixed an issue where the api_key value was being removed from the state file (where it was previously present) after consecutive terraform apply runs.
+  - This does not affect the api_key field in the resource, which is still only available after Create operations. Reading an existing integration will not return this field.
+
 ## v1.1.3
 
 #### Product:

--- a/internal/provider/api_integration_resource.go
+++ b/internal/provider/api_integration_resource.go
@@ -104,7 +104,7 @@ func (r *ApiIntegrationResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	data = ApiIntegrationDtoToModel(dtoObj)
+	data = ApiIntegrationDtoToModel(dtoObj, data)
 
 	tflog.Trace(ctx, "Created the ApiIntegrationResource")
 
@@ -152,7 +152,7 @@ func (r *ApiIntegrationResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	data = ApiIntegrationDtoToModel(ApiIntegration)
+	data = ApiIntegrationDtoToModel(ApiIntegration, data)
 
 	tflog.Trace(ctx, "Read the ApiIntegrationResource")
 
@@ -201,7 +201,7 @@ func (r *ApiIntegrationResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	data = ApiIntegrationDtoToModel(dtoObj)
+	data = ApiIntegrationDtoToModel(dtoObj, data)
 
 	tflog.Trace(ctx, "Updated the ApiIntegrationResource")
 

--- a/internal/provider/convertions.go
+++ b/internal/provider/convertions.go
@@ -714,7 +714,7 @@ func ApiIntegrationMaintenanceSourceDtoToModel(dto dto.MaintenanceSource) dataMo
 	}
 }
 
-func ApiIntegrationDtoToModel(dtoObj dto.ApiIntegration) dataModels.ApiIntegrationModel {
+func ApiIntegrationDtoToModel(dtoObj dto.ApiIntegration, oldModel dataModels.ApiIntegrationModel) dataModels.ApiIntegrationModel {
 	typeSpecificProperties, _ := json.Marshal(dtoObj.TypeSpecificProperties)
 	model := dataModels.ApiIntegrationModel{
 		Id:                     types.StringValue(dtoObj.Id),
@@ -731,6 +731,8 @@ func ApiIntegrationDtoToModel(dtoObj dto.ApiIntegration) dataModels.ApiIntegrati
 
 	if dtoObj.ApiKey != "" {
 		model.ApiKey = types.StringValue(dtoObj.ApiKey)
+	} else if !(oldModel.ApiKey.IsNull() || oldModel.ApiKey.IsUnknown()) {
+		model.ApiKey = types.StringValue(oldModel.ApiKey.ValueString())
 	} else {
 		model.ApiKey = types.StringNull()
 	}


### PR DESCRIPTION
…te file (where it was previously present) after consecutive terraform apply runs.

This does not affect the api_key field in the resource, which is still only available after Create operations. Reading an existing integration will not return this field.