### PR TITLE
Fix documentation regarding Team resource and incorrect casing for `team_type` property

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -30,7 +30,7 @@ Team data source
 - `description` (String) A detailed description of the team's purpose, responsibilities, and scope of operations.
 - `display_name` (String) The human-readable name of the team as it appears in the Atlassian interface.
 - `member` (Attributes Set) The set of users who are members of this team. Each member has their own role and permissions. (see [below for nested schema](#nestedatt--member))
-- `team_type` (String) The type of team (e.g., 'open', 'member_invite', 'external'). Determines team access and invitation policies.
+- `team_type` (String) The type of team (e.g., `OPEN`, `MEMBER_INVITE`, `EXTERNAL`). Determines team access and invitation policies.
 - `user_permissions` (Attributes) The set of permissions that define what operations users can perform on this team. (see [below for nested schema](#nestedatt--user_permissions))
 
 <a id="nestedatt--member"></a>

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -21,7 +21,7 @@ description: |-
 - `display_name` (String) The human-readable name of the team as it appears in the Atlassian interface. This should be clear and identifiable.
 - `member` (Attributes Set) The set of users who are members of this team. Must contain at least one member. Each member is identified by their Atlassian account ID. (see [below for nested schema](#nestedatt--member))
 - `organization_id` (String) The unique identifier of the organization this team belongs to. This determines the team's organizational context.
-- `team_type` (String) The type of team that determines access and invitation policies. Valid values are 'open' (anyone can join), 'member_invite' (members can invite others), or 'external' (managed externally).
+- `team_type` (String) The type of team that determines access and invitation policies. Valid values are `OPEN` (anyone can join), `MEMBER_INVITE` (members can invite others), or `EXTERNAL` (managed externally).
 
 ### Optional
 

--- a/internal/provider/schemaAttributes/team_data_source_attributes.go
+++ b/internal/provider/schemaAttributes/team_data_source_attributes.go
@@ -32,7 +32,7 @@ var TeamDataSourceAttributes = map[string]schema.Attribute{
 		},
 	},
 	"team_type": schema.StringAttribute{
-		Description: "The type of team (e.g., 'open', 'member_invite', 'external'). Determines team access and invitation policies.",
+		Description: "The type of team (e.g., 'OPEN', 'MEMBER_INVITE', 'EXTERNAL'). Determines team access and invitation policies.",
 		Computed:    true,
 	},
 	"user_permissions": schema.SingleNestedAttribute{

--- a/internal/provider/schemaAttributes/team_resource_attributes.go
+++ b/internal/provider/schemaAttributes/team_resource_attributes.go
@@ -39,7 +39,7 @@ var TeamResourceAttributes = map[string]schema.Attribute{
 		},
 	},
 	"team_type": schema.StringAttribute{
-		Description: "The type of team that determines access and invitation policies. Valid values are 'open' (anyone can join), 'member_invite' (members can invite others), or 'external' (managed externally).",
+		Description: "The type of team that determines access and invitation policies. Valid values are 'OPEN' (anyone can join), 'MEMBER_INVITE' (members can invite others), or 'EXTERNAL' (managed externally).",
 		Required:    true,
 		Validators: []validator.String{
 			stringvalidator.OneOf(string(dto.OPEN), string(dto.MEMBER_INVITE), string(dto.EXTERNAL)),


### PR DESCRIPTION
Noted the documentation is wrong, `team_type` values are `ALL CAPS` with the following values:

- `OPEN`
- `MEMBER_INVITE`
- `EXTERNAL`
