### PR TITLE
Fixes an issue where policy order updates were failing silently, causing Terraform drift and potential resources to be created with incorrect order values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@
 This project aims to enable users to manipulate Operations resources in Atlassian (Jira Service Management and Compass), via Terraform.
 It is a functional replication of the _now transitioned_ [Opsgenie Provider](https://github.com/opsgenie/terraform-provider-opsgenie).
 
+## Contact Support
+
+We don’t track or manage Terraform Provider issues via GitHub. Instead, we use Atlassian’s public issue tracker and support portal so that all requests can be properly triaged and followed up.
+
+Check existing bug reports and suggestions
+Please first check whether your request has already been reported here:
+
+👉 [Atlassian Operations Terraform Provider Existing Issues](https://jira.atlassian.com/browse/JSDCLOUD-17980?jql=project%3D%22Jira%20Service%20Management%20Cloud%22%20%20AND%20component%20in%20(%22Operations%20-%20Terraform%20Provider%22)%20and%20resolution%20is%20EMPTY)
+
+If you find an issue that matches what you’re seeing, please vote for it and watch it for updates. This helps us prioritise and keeps you informed.
+
+If you don’t find a matching issue
+If nothing there matches your bug or feature request, please create a ticket with our Support team here:
+
+👉 [Atlassian Support](https://support.atlassian.com/contact/#/)
+
+Thank you again for your feedback and for helping us improve the Terraform Provider.
+
+
+## Provider Resources
+
 The provider is still under development. It currently supports the following resources:
 
 * Team

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The provider is still under development. It currently supports the following res
 * Routing Rule
 * Custom Role
 * Alert Policy
+* Notification Policy
 * User Contact
 
 And the following data sources:
@@ -22,6 +23,54 @@ And the following data sources:
 * Schedule (**excl.** Rotation)
 
 \*Due to the internal structure of the Operations, _user_ is implemented solely as a data source and supports **read operations only**.
+
+## Important Notes
+
+### Policy Ordering
+
+Both Alert Policies and Notification Policies support an optional `order` attribute to control the execution order of policies. However, due to how the Atlassian Operations API handles policy ordering, there are important constraints:
+
+#### Requirements for Using `order`
+
+1. **Must be >= 1**: The order attribute accepts values starting from 1 (first position), 2 (second position), etc.
+2. **Requires `depends_on`**: To ensure reliable ordering, you **must** use Terraform's `depends_on` to create policies sequentially.
+
+**Example:**
+```hcl
+resource "atlassian-operations_notification_policy" "policy_1" {
+  name    = "First Policy"
+  order   = 1
+  team_id = var.team_id
+  # ... other attributes
+}
+
+resource "atlassian-operations_notification_policy" "policy_2" {
+  name    = "Second Policy"
+  order   = 2
+  team_id = var.team_id
+  # ... other attributes
+  
+  depends_on = [atlassian-operations_notification_policy.policy_1]
+}
+
+resource "atlassian-operations_notification_policy" "policy_3" {
+  name    = "Third Policy"
+  order   = 3
+  team_id = var.team_id
+  # ... other attributes
+  
+  depends_on = [atlassian-operations_notification_policy.policy_2]
+}
+```
+
+#### Alternative: Skip `order` and Use UI
+
+If managing `depends_on` chains is too complex, you can:
+1. Omit the `order` attribute entirely
+2. Let Terraform create policies in any order
+3. Manually reorder policies in the Atlassian Operations UI
+
+This approach is simpler and still allows you to manage policy configurations via Terraform while handling ordering through the UI.
 
 ### Related Links
 

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -11,6 +11,12 @@ definitions:
         name: Build
         script:
           - go build .
+    - step: &cleanup-email-contacts
+        name: Cleanup Email Contacts
+        script:
+          - apt-get update && apt-get install -y jq
+          - chmod +x scripts/cleanup-email-contacts.sh
+          - ./scripts/cleanup-email-contacts.sh
     - step: &jsmTest
         name: JSM Test
         script:
@@ -56,8 +62,11 @@ pipelines:
   custom:
     replicate-to-github:
         - step: *replicate-to-github
+    cleanup-email-contacts:
+        - step: *cleanup-email-contacts
   pull-requests:
     '**':
+      - step: *cleanup-email-contacts
       - step: *jsmTest
       - step: *compassTest
 #     - step: *lint

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -126,7 +126,11 @@ func (r *AlertPolicyResource) Create(ctx context.Context, req resource.CreateReq
 		if requestedOrder < 0 {
 			requestedOrder = 0
 		}
-		r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder)
+		if err := r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder); err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Failed to set order for alert policy: %s", err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to set order for alert policy: %s", err))
+			return
+		}
 	}
 
 	order := getAlertPolicyOrder(ctx, r.clientConfiguration, teamId, alertPolicyDto.ID)
@@ -264,7 +268,11 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 		if requestedOrder < 0 {
 			requestedOrder = 0
 		}
-		r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder)
+		if err := r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder); err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Failed to set order for alert policy: %s", err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to set order for alert policy: %s", err))
+			return
+		}
 	}
 
 	order := getAlertPolicyOrder(ctx, r.clientConfiguration, teamId, alertPolicyDto.ID)
@@ -407,7 +415,7 @@ func getAlertPolicyOrder(ctx context.Context, configuration dto.AtlassianOpsProv
 	return order
 }
 
-func (r *AlertPolicyResource) updatePolicyOrder(ctx context.Context, teamId string, policyId string, requestedOrder int32) {
+func (r *AlertPolicyResource) updatePolicyOrder(ctx context.Context, teamId string, policyId string, requestedOrder int32) error {
 	var orderBaseUrl string
 	if teamId == "" {
 		orderBaseUrl = fmt.Sprintf("/v1/alerts/policies/%s/change-order", policyId)
@@ -424,16 +432,22 @@ func (r *AlertPolicyResource) updatePolicyOrder(ctx context.Context, teamId stri
 		SetBody(orderDto).
 		Send()
 
+	if orderResp == nil {
+		return fmt.Errorf("unable to set order for alert policy, got nil response")
+	}
+
 	if orderResp.IsError() {
 		statusCode := orderResp.GetStatusCode()
 		errorResponse := orderResp.GetErrorBody()
 		if errorResponse != nil {
-			tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for alert policy, status code: %d. Got response: %s", statusCode, *errorResponse))
-		} else {
-			tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for alert policy, got http response: %d", statusCode))
+			return fmt.Errorf("unable to set order for alert policy, status code: %d. Got response: %s", statusCode, *errorResponse)
 		}
+		return fmt.Errorf("unable to set order for alert policy, got http response: %d", statusCode)
 	}
+
 	if orderErr != nil {
-		tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for alert policy, got error: %s", orderErr))
+		return fmt.Errorf("unable to set order for alert policy, got error: %s", orderErr)
 	}
+
+	return nil
 }

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -114,17 +114,17 @@ func (r *AlertPolicyResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	var teamId string
+	if !data.TeamID.IsUnknown() && !data.TeamID.IsNull() {
+		teamId = data.TeamID.ValueString()
+	}
+
 	if !data.Order.IsUnknown() && !data.Order.IsNull() {
 		requestedOrder := int32(data.Order.ValueInt64())
-		var teamId string
-		if !data.TeamID.IsUnknown() && !data.TeamID.IsNull() {
-			teamId = data.TeamID.ValueString()
-		}
-		
 		r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder)
 	}
 
-	order := getAlertPolicyOrder(ctx, r.clientConfiguration, data.TeamID.ValueString(), alertPolicyDto.ID)
+	order := getAlertPolicyOrder(ctx, r.clientConfiguration, teamId, alertPolicyDto.ID)
 	// Update state with response
 	result, _ := AlertPolicyDtoToModel(ctx, order, alertPolicyDto)
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
@@ -186,7 +186,11 @@ func (r *AlertPolicyResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	order := getAlertPolicyOrder(ctx, r.clientConfiguration, data.TeamID.ValueString(), alertPolicyDto.ID)
+	var teamId string
+	if !data.TeamID.IsUnknown() && !data.TeamID.IsNull() {
+		teamId = data.TeamID.ValueString()
+	}
+	order := getAlertPolicyOrder(ctx, r.clientConfiguration, teamId, alertPolicyDto.ID)
 
 	result, _ := AlertPolicyDtoToModel(ctx, order, &alertPolicyDto)
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
@@ -243,17 +247,17 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 	
+	var teamId string
+	if !data.TeamID.IsUnknown() && !data.TeamID.IsNull() {
+		teamId = data.TeamID.ValueString()
+	}
+
 	if !data.Order.IsUnknown() && !data.Order.IsNull() {
 		requestedOrder := int32(data.Order.ValueInt64())
-		var teamId string
-		if !data.TeamID.IsUnknown() && !data.TeamID.IsNull() {
-			teamId = data.TeamID.ValueString()
-		}
-		
 		r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder)
 	}
-	
-	order := getAlertPolicyOrder(ctx, r.clientConfiguration, data.TeamID.ValueString(), alertPolicyDto.ID)
+
+	order := getAlertPolicyOrder(ctx, r.clientConfiguration, teamId, alertPolicyDto.ID)
 	result, _ := AlertPolicyDtoToModel(ctx, order, alertPolicyDto)
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
 }
@@ -322,7 +326,12 @@ func (r *AlertPolicyResource) ImportState(ctx context.Context, req resource.Impo
 func getAlertPolicyOrder(ctx context.Context, configuration dto.AtlassianOpsProviderModel, teamId string, alertPolicyId string) int64 {
 	// list alert policies find the one we just created, and get its order value
 	listAlertPoliciesResponse := &dto.AlertPolicyListDto{}
-	baseURL := fmt.Sprintf("/v1/teams/%s/policies", teamId)
+	var baseURL string
+	if teamId == "" {
+		baseURL = "/v1/alerts/policies"
+	} else {
+		baseURL = fmt.Sprintf("/v1/teams/%s/policies", teamId)
+	}
 	queryParams := map[string]string{
 		"type": "alert",
 	}

--- a/internal/provider/alert_policy_resource.go
+++ b/internal/provider/alert_policy_resource.go
@@ -120,7 +120,12 @@ func (r *AlertPolicyResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	if !data.Order.IsUnknown() && !data.Order.IsNull() {
-		requestedOrder := int32(data.Order.ValueInt64())
+		// Convert from 1-indexed (user input) to 0-indexed (API expects)
+		// User provides: 1, 2, 3... → API expects: 0, 1, 2...
+		requestedOrder := int32(data.Order.ValueInt64() - 1)
+		if requestedOrder < 0 {
+			requestedOrder = 0
+		}
 		r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder)
 	}
 
@@ -246,14 +251,19 @@ func (r *AlertPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update alert policy, got error: %s", err))
 		return
 	}
-	
+
 	var teamId string
 	if !data.TeamID.IsUnknown() && !data.TeamID.IsNull() {
 		teamId = data.TeamID.ValueString()
 	}
 
 	if !data.Order.IsUnknown() && !data.Order.IsNull() {
-		requestedOrder := int32(data.Order.ValueInt64())
+		// Convert from 1-indexed (user input) to 0-indexed (API expects)
+		// User provides: 1, 2, 3... → API expects: 0, 1, 2...
+		requestedOrder := int32(data.Order.ValueInt64() - 1)
+		if requestedOrder < 0 {
+			requestedOrder = 0
+		}
 		r.updatePolicyOrder(ctx, teamId, alertPolicyDto.ID, requestedOrder)
 	}
 
@@ -404,7 +414,7 @@ func (r *AlertPolicyResource) updatePolicyOrder(ctx context.Context, teamId stri
 	} else {
 		orderBaseUrl = fmt.Sprintf("/v1/teams/%s/policies/%s/change-order", teamId, policyId)
 	}
-	
+
 	orderDto := map[string]int32{"order": requestedOrder}
 
 	orderResp, orderErr := httpClientHelpers.

--- a/internal/provider/heartbeat_resource_test.go
+++ b/internal/provider/heartbeat_resource_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccHeartbeatResource(t *testing.T) {
 	teamName := uuid.NewString()
+	heartbeatName := uuid.NewString()
 
 	organizationId := os.Getenv("ATLASSIAN_ACCTEST_ORGANIZATION_ID")
 	emailPrimary := os.Getenv("ATLASSIAN_ACCTEST_EMAIL_PRIMARY")
@@ -28,9 +29,9 @@ func TestAccHeartbeatResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: providerConfig + testAccHeartbeatResourceConfig(teamName, emailPrimary, organizationId),
+				Config: providerConfig + testAccHeartbeatResourceConfig(teamName, heartbeatName, emailPrimary, organizationId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "name", "test-heartbeat"),
+					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "name", heartbeatName),
 					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "description", "Test heartbeat"),
 					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "interval", "5"),
 					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "interval_unit", "minutes"),
@@ -57,9 +58,9 @@ func TestAccHeartbeatResource(t *testing.T) {
 			},
 			// Update and Read testing
 			{
-				Config: providerConfig + testAccHeartbeatResourceUpdatedConfig(teamName, emailPrimary, organizationId),
+				Config: providerConfig + testAccHeartbeatResourceUpdatedConfig(teamName, heartbeatName, emailPrimary, organizationId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "name", "test-heartbeat"),
+					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "name", heartbeatName),
 					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "description", "Updated test heartbeat"),
 					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "interval", "10"),
 					resource.TestCheckResourceAttr("atlassian-operations_heartbeat.test", "interval_unit", "minutes"),
@@ -74,7 +75,7 @@ func TestAccHeartbeatResource(t *testing.T) {
 	})
 }
 
-func testAccHeartbeatResourceConfig(teamName string, emailPrimary string, organizationId string) string {
+func testAccHeartbeatResourceConfig(teamName string, heartbeatName string, emailPrimary string, organizationId string) string {
 	return `
 data "atlassian-operations_user" "test1" {
 	email_address = "` + emailPrimary + `"
@@ -94,7 +95,7 @@ resource "atlassian-operations_team" "example" {
 }
 
 resource "atlassian-operations_heartbeat" "test" {
-  name          = "test-heartbeat"
+  name          = "` + heartbeatName + `"
   description   = "Test heartbeat"
   interval      = 5
   interval_unit = "minutes"
@@ -107,7 +108,7 @@ resource "atlassian-operations_heartbeat" "test" {
 `
 }
 
-func testAccHeartbeatResourceUpdatedConfig(teamName string, emailPrimary string, organizationId string) string {
+func testAccHeartbeatResourceUpdatedConfig(teamName string, heartbeatName string, emailPrimary string, organizationId string) string {
 	return `
 data "atlassian-operations_user" "test1" {
 	email_address = "` + emailPrimary + `"
@@ -127,7 +128,7 @@ resource "atlassian-operations_team" "example" {
 }
 
 resource "atlassian-operations_heartbeat" "test" {
-  name          = "test-heartbeat"
+  name          = "` + heartbeatName + `"
   description   = "Updated test heartbeat"
   interval      = 10
   interval_unit = "minutes"

--- a/internal/provider/notification_policy_resource.go
+++ b/internal/provider/notification_policy_resource.go
@@ -115,7 +115,11 @@ func (r *NotificationPolicyResource) Create(ctx context.Context, req resource.Cr
 		if requestedOrder < 0 {
 			requestedOrder = 0
 		}
-		r.updatePolicyOrder(ctx, data.TeamID.ValueString(), notificationPolicyDto.ID, requestedOrder)
+		if err := r.updatePolicyOrder(ctx, data.TeamID.ValueString(), notificationPolicyDto.ID, requestedOrder); err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Failed to set order for notification policy: %s", err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to set order for notification policy: %s", err))
+			return
+		}
 	}
 
 	// list notification policies find the one we just created, and get its order value
@@ -232,7 +236,11 @@ func (r *NotificationPolicyResource) Update(ctx context.Context, req resource.Up
 		if requestedOrder < 0 {
 			requestedOrder = 0
 		}
-		r.updatePolicyOrder(ctx, data.TeamID.ValueString(), notificationPolicyDto.ID, requestedOrder)
+		if err := r.updatePolicyOrder(ctx, data.TeamID.ValueString(), notificationPolicyDto.ID, requestedOrder); err != nil {
+			tflog.Error(ctx, fmt.Sprintf("Failed to set order for notification policy: %s", err))
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to set order for notification policy: %s", err))
+			return
+		}
 	}
 
 	order := getNotificationPolicyOrder(ctx, r.clientConfiguration, data.TeamID.ValueString(), notificationPolicyDto.ID)
@@ -361,7 +369,7 @@ func getNotificationPolicyOrder(ctx context.Context, configuration dto.Atlassian
 	return order
 }
 
-func (r *NotificationPolicyResource) updatePolicyOrder(ctx context.Context, teamId string, policyId string, requestedOrder int32) {
+func (r *NotificationPolicyResource) updatePolicyOrder(ctx context.Context, teamId string, policyId string, requestedOrder int32) error {
 	orderBaseUrl := fmt.Sprintf("/v1/teams/%s/policies/%s/change-order", teamId, policyId)
 	orderDto := map[string]int32{"order": requestedOrder}
 
@@ -373,23 +381,21 @@ func (r *NotificationPolicyResource) updatePolicyOrder(ctx context.Context, team
 		Send()
 
 	if orderResp == nil {
-		tflog.Error(ctx, "Client Error. Unable to set order for notification policy, got nil response")
-		return
+		return fmt.Errorf("unable to set order for notification policy, got nil response")
 	}
 
 	if orderResp.IsError() {
 		statusCode := orderResp.GetStatusCode()
 		errorResponse := orderResp.GetErrorBody()
 		if errorResponse != nil {
-			tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for notification policy, status code: %d. Got response: %s", statusCode, *errorResponse))
-		} else {
-			tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for notification policy, got http response: %d", statusCode))
+			return fmt.Errorf("unable to set order for notification policy, status code: %d. Got response: %s", statusCode, *errorResponse)
 		}
-		return
+		return fmt.Errorf("unable to set order for notification policy, got http response: %d", statusCode)
 	}
 
 	if orderErr != nil {
-		tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for notification policy, got error: %s", orderErr))
-		return
+		return fmt.Errorf("unable to set order for notification policy, got error: %s", orderErr)
 	}
+
+	return nil
 }

--- a/internal/provider/notification_policy_resource.go
+++ b/internal/provider/notification_policy_resource.go
@@ -107,6 +107,17 @@ func (r *NotificationPolicyResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
+	// Set the order if specified by user
+	if !data.Order.IsUnknown() && !data.Order.IsNull() {
+		// Convert from 1-indexed (user input) to 0-indexed (API expects)
+		// User provides: 1, 2, 3... → API expects: 0, 1, 2...
+		requestedOrder := int32(data.Order.ValueFloat64() - 1)
+		if requestedOrder < 0 {
+			requestedOrder = 0
+		}
+		r.updatePolicyOrder(ctx, data.TeamID.ValueString(), notificationPolicyDto.ID, requestedOrder)
+	}
+
 	// list notification policies find the one we just created, and get its order value
 	order := getNotificationPolicyOrder(ctx, r.clientConfiguration, data.TeamID.ValueString(), notificationPolicyDto.ID)
 
@@ -211,6 +222,17 @@ func (r *NotificationPolicyResource) Update(ctx context.Context, req resource.Up
 		tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to update notification policy, got error: %s", err))
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update notification policy, got error: %s", err))
 		return
+	}
+
+	// Set the order if specified by user
+	if !data.Order.IsUnknown() && !data.Order.IsNull() {
+		// Convert from 1-indexed (user input) to 0-indexed (API expects)
+		// User provides: 1, 2, 3... → API expects: 0, 1, 2...
+		requestedOrder := int32(data.Order.ValueFloat64() - 1)
+		if requestedOrder < 0 {
+			requestedOrder = 0
+		}
+		r.updatePolicyOrder(ctx, data.TeamID.ValueString(), notificationPolicyDto.ID, requestedOrder)
 	}
 
 	order := getNotificationPolicyOrder(ctx, r.clientConfiguration, data.TeamID.ValueString(), notificationPolicyDto.ID)
@@ -337,4 +359,37 @@ func getNotificationPolicyOrder(ctx context.Context, configuration dto.Atlassian
 		}
 	}
 	return order
+}
+
+func (r *NotificationPolicyResource) updatePolicyOrder(ctx context.Context, teamId string, policyId string, requestedOrder int32) {
+	orderBaseUrl := fmt.Sprintf("/v1/teams/%s/policies/%s/change-order", teamId, policyId)
+	orderDto := map[string]int32{"order": requestedOrder}
+
+	orderResp, orderErr := httpClientHelpers.
+		GenerateJsmOpsClientRequest(r.clientConfiguration).
+		JoinBaseUrl(orderBaseUrl).
+		Method(httpClient.POST).
+		SetBody(orderDto).
+		Send()
+
+	if orderResp == nil {
+		tflog.Error(ctx, "Client Error. Unable to set order for notification policy, got nil response")
+		return
+	}
+
+	if orderResp.IsError() {
+		statusCode := orderResp.GetStatusCode()
+		errorResponse := orderResp.GetErrorBody()
+		if errorResponse != nil {
+			tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for notification policy, status code: %d. Got response: %s", statusCode, *errorResponse))
+		} else {
+			tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for notification policy, got http response: %d", statusCode))
+		}
+		return
+	}
+
+	if orderErr != nil {
+		tflog.Error(ctx, fmt.Sprintf("Client Error. Unable to set order for notification policy, got error: %s", orderErr))
+		return
+	}
 }

--- a/internal/provider/notification_rule_resource_test.go
+++ b/internal/provider/notification_rule_resource_test.go
@@ -45,10 +45,18 @@ resource "atlassian-operations_team" "example" {
   ]
 }
 
+resource "atlassian-operations_user_contact" "example" {
+  method  = "email"
+  to      = "` + emailPrimary + `"
+  enabled = true
+}
+
 resource "atlassian-operations_notification_rule" "example" {
   name        = "Critical Incident Alert"
   action_type = "create-alert"
   enabled     = true
+
+  depends_on = [atlassian-operations_user_contact.example]
 
   time_restriction = {
     type = "weekday-and-time-of-day"
@@ -133,10 +141,18 @@ resource "atlassian-operations_team" "example" {
   ]
 }
 
+resource "atlassian-operations_user_contact" "example" {
+  method  = "email"
+  to      = "` + emailPrimary + `"
+  enabled = true
+}
+
 resource "atlassian-operations_notification_rule" "example" {
   name        = "Updated Critical Incident Alert"
   action_type = "create-alert"
   enabled     = false
+
+  depends_on = [atlassian-operations_user_contact.example]
 
   time_restriction = {
     type = "time-of-day"
@@ -229,10 +245,18 @@ resource "atlassian-operations_team" "example" {
   ]
 }
 
+resource "atlassian-operations_user_contact" "example" {
+  method  = "email"
+  to      = "` + emailPrimary + `"
+  enabled = true
+}
+
 resource "atlassian-operations_notification_rule" "example" {
   name        = "Critical Incident Alert"
   action_type = "schedule-start"
   enabled     = true
+
+  depends_on = [atlassian-operations_user_contact.example]
 
   time_restriction = {
     type = "weekday-and-time-of-day"
@@ -311,10 +335,18 @@ resource "atlassian-operations_team" "example" {
   ]
 }
 
+resource "atlassian-operations_user_contact" "example" {
+  method  = "email"
+  to      = "` + emailPrimary + `"
+  enabled = true
+}
+
 resource "atlassian-operations_notification_rule" "example" {
   name        = "Updated Critical Incident Alert"
   action_type = "schedule-start"
   enabled     = false
+
+  depends_on = [atlassian-operations_user_contact.example]
 
   time_restriction = {
     type = "time-of-day"

--- a/internal/provider/schemaAttributes/alert_policy_resource_attributes.go
+++ b/internal/provider/schemaAttributes/alert_policy_resource_attributes.go
@@ -1,6 +1,7 @@
 package schemaAttributes
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -48,7 +49,10 @@ var AlertPolicyResourceAttributes = map[string]schema.Attribute{
 	"order": schema.Int64Attribute{
 		Optional:    true,
 		Computed:    true,
-		Description: "The order of the alert policy",
+		Description: "The order of the alert policy. Must be >= 1 (1 means first position, 2 means second, etc.). Requires explicit depends_on to ensure sequential creation.",
+		Validators: []validator.Int64{
+			int64validator.AtLeast(1),
+		},
 	},
 	"filter": schema.SingleNestedAttribute{
 		Optional:    true,

--- a/internal/provider/schemaAttributes/notification_policy_resource_attributes.go
+++ b/internal/provider/schemaAttributes/notification_policy_resource_attributes.go
@@ -2,6 +2,7 @@ package schemaAttributes
 
 import (
 	"github.com/atlassian/terraform-provider-atlassian-operations/internal/provider/schemaAttributes/customValidators"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -51,7 +52,10 @@ var NotificationPolicyResourceAttributes = map[string]schema.Attribute{
 	"order": schema.Float64Attribute{
 		Optional:    true,
 		Computed:    true,
-		Description: "Order of the notification policy",
+		Description: "Order of the notification policy. Must be >= 1 (1 means first position, 2 means second, etc.). Requires explicit depends_on to ensure sequential creation.",
+		Validators: []validator.Float64{
+			float64validator.AtLeast(1),
+		},
 	},
 	"filter": schema.SingleNestedAttribute{
 		Optional:    true,

--- a/scripts/cleanup-email-contacts.sh
+++ b/scripts/cleanup-email-contacts.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+#
+# Cleanup script for test resources created by Terraform provider acceptance tests
+# This script deletes all email user contacts for the authenticated user
+#
+# Required environment variables:
+#   ATLASSIAN_OPS_CLOUD_ID      - The Atlassian Cloud ID
+#   ATLASSIAN_OPS_API_USERNAME  - Username/email for API authentication
+#   ATLASSIAN_OPS_API_TOKEN     - API token for authentication
+#
+# Optional environment variables:
+#   ATLASSIAN_OPS_STAGING       - Set to "1" to use staging API
+#   DRY_RUN                     - Set to "1" to only list resources without deleting
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Helper functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Validate required environment variables
+validate_env() {
+    local missing_vars=()
+    
+    if [[ -z "${ATLASSIAN_OPS_CLOUD_ID:-}" ]]; then
+        missing_vars+=("ATLASSIAN_OPS_CLOUD_ID")
+    fi
+    
+    if [[ -z "${ATLASSIAN_OPS_API_USERNAME:-}" ]]; then
+        missing_vars+=("ATLASSIAN_OPS_API_USERNAME")
+    fi
+    
+    if [[ -z "${ATLASSIAN_OPS_API_TOKEN:-}" ]]; then
+        missing_vars+=("ATLASSIAN_OPS_API_TOKEN")
+    fi
+    
+    if [[ ${#missing_vars[@]} -gt 0 ]]; then
+        log_error "Missing required environment variables:"
+        for var in "${missing_vars[@]}"; do
+            echo "  - $var"
+        done
+        exit 1
+    fi
+}
+
+# Get the base API URL
+get_api_base_url() {
+    local cloud_id="${ATLASSIAN_OPS_CLOUD_ID}"
+    local is_staging="${ATLASSIAN_OPS_STAGING:-0}"
+    
+    local api_domain="https://api.atlassian.com"
+    if [[ "$is_staging" == "1" ]]; then
+        api_domain="https://api.stg.atlassian.com"
+    fi
+    
+    echo "${api_domain}/jsm/ops/api/${cloud_id}"
+}
+
+# Get auth header for curl
+get_auth_header() {
+    local username="${ATLASSIAN_OPS_API_USERNAME}"
+    local token="${ATLASSIAN_OPS_API_TOKEN}"
+    echo "${username}:${token}"
+}
+
+# Cleanup all user contacts
+cleanup_user_contacts() {
+    log_info "Cleaning up user contact resources..."
+    
+    local base_url
+    base_url=$(get_api_base_url)
+    local auth
+    auth=$(get_auth_header)
+    local dry_run="${DRY_RUN:-0}"
+    
+    # List all user contacts
+    log_info "Fetching user contacts..."
+    local response
+    response=$(curl -s -w "\n%{http_code}" \
+        -X GET \
+        -H "Content-Type: application/json" \
+        -u "$auth" \
+        "${base_url}/v1/users/contacts") || {
+        log_error "curl command failed"
+        return 1
+    }
+    
+    local http_code
+    http_code=$(echo "$response" | tail -n1)
+    local body
+    body=$(echo "$response" | sed '$d')
+    
+    log_info "HTTP Status: $http_code"
+    
+    if [[ "$http_code" != "200" ]]; then
+        log_error "Failed to list user contacts. HTTP $http_code"
+        log_error "Response: $body"
+        return 1
+    fi
+    
+    log_info "Successfully fetched contacts"
+    
+    # Use jq to parse the JSON response
+    if ! command -v jq &> /dev/null; then
+        log_error "jq is required but not installed. Please install jq."
+        exit 1
+    fi
+    
+    # Debug: show response structure
+    log_info "Response preview: $(echo "$body" | head -c 200)..."
+    
+    # Check if response has values array (list response) or is a single object
+    local contacts=""
+    if echo "$body" | jq -e '.values' > /dev/null 2>&1; then
+        local count
+        count=$(echo "$body" | jq '.values | length')
+        log_info "Found $count contacts in response"
+        if [[ "$count" -gt 0 ]]; then
+            contacts=$(echo "$body" | jq -r '.values[] | @base64')
+        fi
+    else
+        # Single contact or different structure - try to parse as array
+        log_info "Response doesn't have .values, trying alternative parsing..."
+        contacts=$(echo "$body" | jq -r '.[]? | @base64' 2>/dev/null || echo "")
+    fi
+    
+    if [[ -z "$contacts" ]]; then
+        log_info "No user contacts found."
+        return 0
+    fi
+    
+    local deleted_count=0
+    local found_count=0
+    
+    for contact in $contacts; do
+        local contact_json
+        # Use -d for Linux compatibility (--decode works on macOS)
+        contact_json=$(echo "$contact" | base64 -d 2>/dev/null || echo "$contact" | base64 --decode)
+        
+        local contact_id
+        contact_id=$(echo "$contact_json" | jq -r '.id // empty')
+        local contact_to
+        contact_to=$(echo "$contact_json" | jq -r '.to // empty')
+        local contact_method
+        contact_method=$(echo "$contact_json" | jq -r '.method // empty')
+        
+        if [[ -z "$contact_id" ]]; then
+            continue
+        fi
+        
+        # Only delete email contacts
+        if [[ "$contact_method" != "email" ]]; then
+            log_info "Skipping non-email contact: id=$contact_id, method=$contact_method, to=$contact_to"
+            continue
+        fi
+        
+        found_count=$((found_count + 1))
+        log_info "Found email contact: id=$contact_id, to=$contact_to"
+        
+        if [[ "$dry_run" == "1" ]]; then
+            log_warning "[DRY RUN] Would delete contact: $contact_id"
+        else
+            # Delete the contact
+            log_info "Deleting contact: $contact_id"
+            local delete_response
+            delete_response=$(curl -s -w "\n%{http_code}" \
+                -X DELETE \
+                -H "Content-Type: application/json" \
+                -u "$auth" \
+                "${base_url}/v1/users/contacts/${contact_id}")
+            
+            local delete_http_code
+            delete_http_code=$(echo "$delete_response" | tail -n1)
+            
+            if [[ "$delete_http_code" == "200" ]] || [[ "$delete_http_code" == "204" ]]; then
+                log_success "Deleted contact: $contact_id"
+                deleted_count=$((deleted_count + 1))
+            else
+                local delete_body
+                delete_body=$(echo "$delete_response" | sed '$d')
+                log_error "Failed to delete contact $contact_id. HTTP $delete_http_code"
+                log_error "Response: $delete_body"
+            fi
+        fi
+    done
+    
+    echo ""
+    log_info "Summary:"
+    log_info "  Found email contacts: $found_count"
+    if [[ "$dry_run" == "1" ]]; then
+        log_warning "  [DRY RUN] No contacts were deleted"
+    else
+        log_success "  Deleted email contacts: $deleted_count"
+    fi
+}
+
+# Main cleanup function
+main() {
+    echo "=========================================="
+    echo "  Terraform Provider Test Resource Cleanup"
+    echo "=========================================="
+    echo ""
+    
+    # Validate environment
+    validate_env
+    
+    local base_url
+    base_url=$(get_api_base_url)
+    log_info "API Base URL: $base_url"
+    
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        log_warning "DRY RUN MODE - No resources will be deleted"
+    fi
+    
+    echo ""
+    
+    # Run cleanup for user contacts
+    cleanup_user_contacts
+    
+    echo ""
+    log_success "Cleanup complete!"
+}
+
+# Run main function
+main "$@"
+

--- a/scripts/cleanup-test-resources.sh
+++ b/scripts/cleanup-test-resources.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+#
+# Cleanup script for test resources created by Terraform provider acceptance tests
+# This script deletes all email user contacts for the authenticated user
+#
+# Required environment variables:
+#   ATLASSIAN_OPS_CLOUD_ID          - The Atlassian Cloud ID
+#   ATLASSIAN_OPS_API_EMAIL_ADDRESS - Email address for API authentication
+#   ATLASSIAN_OPS_API_TOKEN         - API token for authentication
+#
+# Optional environment variables:
+#   ATLASSIAN_OPS_STAGING           - Set to "1" to use staging API
+#   DRY_RUN                         - Set to "1" to only list resources without deleting
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Helper functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Validate required environment variables
+validate_env() {
+    local missing_vars=()
+    
+    if [[ -z "${ATLASSIAN_OPS_CLOUD_ID:-}" ]]; then
+        missing_vars+=("ATLASSIAN_OPS_CLOUD_ID")
+    fi
+    
+    if [[ -z "${ATLASSIAN_OPS_API_EMAIL_ADDRESS:-}" ]]; then
+        missing_vars+=("ATLASSIAN_OPS_API_EMAIL_ADDRESS")
+    fi
+    
+    if [[ -z "${ATLASSIAN_OPS_API_TOKEN:-}" ]]; then
+        missing_vars+=("ATLASSIAN_OPS_API_TOKEN")
+    fi
+    
+    if [[ ${#missing_vars[@]} -gt 0 ]]; then
+        log_error "Missing required environment variables:"
+        for var in "${missing_vars[@]}"; do
+            echo "  - $var"
+        done
+        exit 1
+    fi
+}
+
+# Get the base API URL
+get_api_base_url() {
+    local cloud_id="${ATLASSIAN_OPS_CLOUD_ID}"
+    local is_staging="${ATLASSIAN_OPS_STAGING:-0}"
+    
+    local api_domain="https://api.atlassian.com"
+    if [[ "$is_staging" == "1" ]]; then
+        api_domain="https://api.stg.atlassian.com"
+    fi
+    
+    echo "${api_domain}/jsm/ops/api/${cloud_id}"
+}
+
+# Get auth header for curl
+get_auth_header() {
+    local email="${ATLASSIAN_OPS_API_EMAIL_ADDRESS}"
+    local token="${ATLASSIAN_OPS_API_TOKEN}"
+    echo "${email}:${token}"
+}
+
+# Cleanup all user contacts
+cleanup_user_contacts() {
+    log_info "Cleaning up user contact resources..."
+    
+    local base_url
+    base_url=$(get_api_base_url)
+    local auth
+    auth=$(get_auth_header)
+    local dry_run="${DRY_RUN:-0}"
+    
+    # List all user contacts
+    log_info "Fetching user contacts..."
+    local response
+    response=$(curl -s -w "\n%{http_code}" \
+        -X GET \
+        -H "Content-Type: application/json" \
+        -u "$auth" \
+        "${base_url}/v1/users/contacts")
+    
+    local http_code
+    http_code=$(echo "$response" | tail -n1)
+    local body
+    body=$(echo "$response" | sed '$d')
+    
+    if [[ "$http_code" != "200" ]]; then
+        log_error "Failed to list user contacts. HTTP $http_code"
+        log_error "Response: $body"
+        return 1
+    fi
+    
+    # Use jq to parse the JSON response
+    if ! command -v jq &> /dev/null; then
+        log_error "jq is required but not installed. Please install jq."
+        exit 1
+    fi
+    
+    # Check if response has values array (list response) or is a single object
+    local contacts
+    if echo "$body" | jq -e '.values' > /dev/null 2>&1; then
+        contacts=$(echo "$body" | jq -r '.values[]? | @base64')
+    else
+        # Single contact or different structure - try to parse as array
+        contacts=$(echo "$body" | jq -r '.[]? | @base64' 2>/dev/null || echo "")
+    fi
+    
+    if [[ -z "$contacts" ]]; then
+        log_info "No user contacts found."
+        return 0
+    fi
+    
+    local deleted_count=0
+    local found_count=0
+    
+    for contact in $contacts; do
+        local contact_json
+        contact_json=$(echo "$contact" | base64 --decode)
+        
+        local contact_id
+        contact_id=$(echo "$contact_json" | jq -r '.id // empty')
+        local contact_to
+        contact_to=$(echo "$contact_json" | jq -r '.to // empty')
+        local contact_method
+        contact_method=$(echo "$contact_json" | jq -r '.method // empty')
+        
+        if [[ -z "$contact_id" ]]; then
+            continue
+        fi
+        
+        # Only delete email contacts
+        if [[ "$contact_method" != "email" ]]; then
+            log_info "Skipping non-email contact: id=$contact_id, method=$contact_method, to=$contact_to"
+            continue
+        fi
+        
+        ((found_count++))
+        log_info "Found email contact: id=$contact_id, to=$contact_to"
+        
+        if [[ "$dry_run" == "1" ]]; then
+            log_warning "[DRY RUN] Would delete contact: $contact_id"
+        else
+            # Delete the contact
+            log_info "Deleting contact: $contact_id"
+            local delete_response
+            delete_response=$(curl -s -w "\n%{http_code}" \
+                -X DELETE \
+                -H "Content-Type: application/json" \
+                -u "$auth" \
+                "${base_url}/v1/users/contacts/${contact_id}")
+            
+            local delete_http_code
+            delete_http_code=$(echo "$delete_response" | tail -n1)
+            
+            if [[ "$delete_http_code" == "200" ]] || [[ "$delete_http_code" == "204" ]]; then
+                log_success "Deleted contact: $contact_id"
+                ((deleted_count++))
+            else
+                local delete_body
+                delete_body=$(echo "$delete_response" | sed '$d')
+                log_error "Failed to delete contact $contact_id. HTTP $delete_http_code"
+                log_error "Response: $delete_body"
+            fi
+        fi
+    done
+    
+    echo ""
+    log_info "Summary:"
+    log_info "  Found email contacts: $found_count"
+    if [[ "$dry_run" == "1" ]]; then
+        log_warning "  [DRY RUN] No contacts were deleted"
+    else
+        log_success "  Deleted email contacts: $deleted_count"
+    fi
+}
+
+# Main cleanup function
+main() {
+    echo "=========================================="
+    echo "  Terraform Provider Test Resource Cleanup"
+    echo "=========================================="
+    echo ""
+    
+    # Validate environment
+    validate_env
+    
+    local base_url
+    base_url=$(get_api_base_url)
+    log_info "API Base URL: $base_url"
+    
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        log_warning "DRY RUN MODE - No resources will be deleted"
+    fi
+    
+    echo ""
+    
+    # Run cleanup for user contacts
+    cleanup_user_contacts
+    
+    echo ""
+    log_success "Cleanup complete!"
+}
+
+# Run main function
+main "$@"
+


### PR DESCRIPTION
## Changes
- Changed `updatePolicyOrder` to return errors instead of silently logging them
- Added proper error handling in Create and Update methods for both alert and notification policies
- Errors now surface to users via diagnostics instead of being hidden
- Added nil response check for notification policy order updates
- Updated schema attributes for both alert_policy and notification_policy resources

## Problem
Previously, when policy order updates failed, the errors were only logged but not returned to the user. This caused:
- Resources to be created/updated without the correct order value
- Silent failures that were difficult to debug
- Terraform drift between desired and actual state

## Solution
Order update failures are now properly propagated to users through Terraform diagnostics, ensuring:
- Users are immediately aware of any ordering issues
- Failed operations are properly reported
- No silent state mismatches occur

## Testing
- Verified error messages appear when order updates fail
- Confirmed successful order updates work as expected
- Checked that nil responses are handled gracefully