### PR TITLE
Support optional site_id in team resource import for site-scoped teams

### DIFF
--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -26,7 +26,7 @@ description: |-
 ### Optional
 
 - `delete_default_resources` (Boolean) Set to true to remove default escalation and schedule for newly created team. Be careful its also changes that team routing rule to None. That means you have to define routing rule as well. Defaults to false.
-- `site_id` (String) The identifier of the Atlassian site where this team is configured. Must be between 1 and 255 characters.
+- `site_id` (String) The identifier of the Atlassian site where this team is configured. Must be between 1 and 255 characters. When importing a team that is scoped to a site, include the site_id as the third parameter in the import identifier (see Import section below).
 
 ### Read-Only
 

--- a/examples/resources/team/import.sh
+++ b/examples/resources/team/import.sh
@@ -1,2 +1,5 @@
-# Team can be imported by providing the team id and the organization id, seperated by a comma
+# Team can be imported by providing the team id and the organization id, separated by a comma
 terraform import atlassian-operations_team.example "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# When teams are scoped to a site, provide the site id as the third parameter
+terraform import atlassian-operations_team.example "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -686,15 +686,18 @@ func (r *TeamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 func (r *TeamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	idParts := strings.Split(req.ID, ",")
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+	if len(idParts) < 2 || len(idParts) > 3 || idParts[0] == "" || idParts[1] == "" || (len(idParts) == 3 && idParts[2] == "") {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: id,organization_id. Got: %q", req.ID),
+			fmt.Sprintf("Expected import identifier with format: id,organization_id (without site scoping); or: id,organization_id,site_id (with site scoping). Got: %q", req.ID),
 		)
 		return
 	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_id"), idParts[1])...)
+	if len(idParts) == 3 {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("site_id"), idParts[2])...)
+	}
 }
 
 func (r *TeamResource) fetchTeamMembers(organizationId string, teamId string, siteId string) ([]dto.TeamMember, error) {

--- a/internal/provider/team_resource_test.go
+++ b/internal/provider/team_resource_test.go
@@ -204,6 +204,21 @@ func TestAccTeamResource_withSiteId(t *testing.T) {
 					resource.TestCheckResourceAttr("atlassian-operations_team.example", "member.#", "1"),
 				),
 			},
+			// ImportState testing with site_id
+			{
+				ResourceName:            "atlassian-operations_team.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_default_resources"},
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					return state.RootModule().Resources["atlassian-operations_team.example"].Primary.ID +
+							"," +
+							state.RootModule().Resources["atlassian-operations_team.example"].Primary.Attributes["organization_id"] +
+							"," +
+							state.RootModule().Resources["atlassian-operations_team.example"].Primary.Attributes["site_id"],
+						nil
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION

<!-- Rovo Dev code review status -->
---
<img src="https://i.imgur.com/MCm0FWH.png" alt="" height="12"> <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

